### PR TITLE
3 build warning logical not is only applied to the left hand side of comparison

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -140,5 +140,7 @@ namespace Pins {
     // ADVANCED FEATURES
     constexpr int BALL_PRESENCE = A13;
     constexpr int KICKER = 34;
+    //TODO: CHECK ROLLER PIN
+    constexpr int ROLLER = 255;
     #endif
 }

--- a/include/sensors/ball.h
+++ b/include/sensors/ball.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#define is_ball_close(distance) distance > 350
-#define is_ball_far(distance) distance < 300
+#define is_ball_close(distance) (distance > 350)
+#define is_ball_far(distance) (distance < 300)
 
 class Ball {
 private:


### PR DESCRIPTION
Ho scoperto solo da poco il tuo repo,
l'ho forkato per fare esercizio di refactoring, ma mi premeva segnalarti questo warning che nasconde un bug logico in run time.
 
per maggiori dettagli vedi https://github.com/sabatinipaolo/Luca-RoboCup-Galilei-2025/issues/3